### PR TITLE
Add missing `babel-cli` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@wordpress/babel-plugin-makepot": "^1.0.0",
     "@wordpress/babel-preset-default": "^1.1.2",
     "@wordpress/i18n": "^1.1.0",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.4"
   },


### PR DESCRIPTION
The `build` script uses the `babel` command, so `babel-cli` needs to be listed as a dependency. If it isn't, and the package isn't already installed globally, then the script will fail. For example:

```
> gutenberg-i18n-block@0.1.0 build /Users/iandunn/vhosts/localhost/wp-develop.test/public_html/build/wp-content/plugins/gutenberg-i18n-block
> babel block/src/block.js -o block/block.js

sh: babel: command not found
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! gutenberg-i18n-block@0.1.0 build: `babel block/src/block.js -o block/block.js`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the gutenberg-i18n-block@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/iandunn/.npm/_logs/2018-07-07T18_54_56_380Z-debug.log
```